### PR TITLE
Update caramel executable for v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mix Caramel
 
-A Mix plugin for compiling OCaml files in an existing Mix Project using [caramelc](https://github.com/AbstractMachinesLab/caramel).
+A Mix plugin for compiling OCaml files in an existing Mix Project using [caramel](https://github.com/AbstractMachinesLab/caramel).
 
 ## Installation
 
@@ -27,7 +27,7 @@ Also, in your `mix.exs` file, don't forget to add it as a compiler and source th
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       compilers: [:caramel] ++ Mix.compilers(),
-      caramelc_paths: ["path/to/ml_files"]
+      caramel_paths: ["path/to/ml_files"]
     ]
   end
 

--- a/lib/mix/tasks/compiler/caramel.ex
+++ b/lib/mix/tasks/compiler/caramel.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Compile.Caramel do
 
   def run_caramel(files) do
     Mix.Shell.cmd(
-      "caramelc compile " <> Enum.join(files, " "),
+      "caramel compile " <> Enum.join(files, " "),
       [],
       (fn res -> IO.puts(res) end)
     )

--- a/lib/mix/tasks/compiler/caramel.ex
+++ b/lib/mix/tasks/compiler/caramel.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Compile.Caramel do
 
   def run(_) do
     project = Mix.Project.config()
-    source_paths = project[:caramelc_paths]
+    source_paths = project[:caramel_paths]
     Mix.Compilers.Erlang.assert_valid_erlc_paths(source_paths)
     files = Mix.Utils.extract_files(source_paths, [:ml, :mli])
     run_caramel(files)

--- a/test_projects/test_project/mix.exs
+++ b/test_projects/test_project/mix.exs
@@ -9,7 +9,7 @@ defmodule TestProject.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       compilers: [:caramel] ++ Mix.compilers(),
-      caramelc_paths: ["src"]
+      caramel_paths: ["src"]
     ]
   end
 


### PR DESCRIPTION
In caramel v0.1, the compiler executable is no longer called caramelc but caramel (without c)