### PR TITLE
Nice errors if installer prereqs are not available

### DIFF
--- a/lib/caramel/installer.ex
+++ b/lib/caramel/installer.ex
@@ -23,10 +23,19 @@ defmodule Caramel.Installer do
     Mix.Shell.cmd("mv caramel _build/", [], fn _ -> :ok end)
   end
 
+  defp verify_prereqs(prereqs) do
+    Enum.each(prereqs, fn prereq ->
+      if Mix.Shell.Quiet.cmd("which " <> prereq) != 0 do
+        Mix.raise(prereq <> " is requred to install caramel.")
+      end
+    end)
+  end
+
   def install(version) do
     host_triplet = get_host_triplet()
     tarball_name = tarball_name(version, host_triplet)
     release_url = release_url(version, tarball_name)
+    verify_prereqs(["wget", "tar"])
     download_caramel(version, tarball_name, release_url)
   end
 end


### PR DESCRIPTION
I attempted to use this mix compiler on a fresh mac today and it silently failed because `wget` was not yet installed. This will give the user a nice, obvious error if `wget` or `tar` are not installed.